### PR TITLE
Add fine-grained NER

### DIFF
--- a/notebooks/Fine-grained NER.ipynb
+++ b/notebooks/Fine-grained NER.ipynb
@@ -1,0 +1,318 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Extracting Named Entities with Labels\n",
+    "\n",
+    "## Models\n",
+    "There are several models available through scispaCy, and four of them are trained specifically for NER on biomedical tasks. The outputs of these models allows for fine-grained categorical NER extraction, from cellular components, to genes, organs, tissue types, and more. In order to get the most out of our data, we can combine the outputs of all these models and allow subject matter experts to determine later how data scientists can use particular types of named entities for analysis. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Collecting https://s3-us-west-2.amazonaws.com/ai2-s2-scispacy/releases/v0.2.4/en_ner_craft_md-0.2.4.tar.gz\n",
+      "  Downloading https://s3-us-west-2.amazonaws.com/ai2-s2-scispacy/releases/v0.2.4/en_ner_craft_md-0.2.4.tar.gz (70.1 MB)\n",
+      "\u001b[K     |████████████████████████████████| 70.1 MB 20.5 MB/s eta 0:00:01    |████▋                           | 10.1 MB 4.7 MB/s eta 0:00:13     |███████▉                        | 17.2 MB 4.7 MB/s eta 0:00:12     |████████████████                | 34.9 MB 24.9 MB/s eta 0:00:02     |█████████████████▏              | 37.5 MB 24.9 MB/s eta 0:00:02     |███████████████████             | 41.6 MB 24.9 MB/s eta 0:00:02     |███████████████████████████     | 59.2 MB 24.9 MB/s eta 0:00:01     |████████████████████████████▌   | 62.3 MB 24.9 MB/s eta 0:00:01\n",
+      "\u001b[?25hRequirement already satisfied: spacy>=2.2.1 in /root/anaconda3/envs/covid/lib/python3.7/site-packages (from en-ner-craft-md==0.2.4) (2.2.4)\n",
+      "Requirement already satisfied: cymem<2.1.0,>=2.0.2 in /root/anaconda3/envs/covid/lib/python3.7/site-packages (from spacy>=2.2.1->en-ner-craft-md==0.2.4) (2.0.3)\n",
+      "Requirement already satisfied: wasabi<1.1.0,>=0.4.0 in /root/anaconda3/envs/covid/lib/python3.7/site-packages (from spacy>=2.2.1->en-ner-craft-md==0.2.4) (0.6.0)\n",
+      "Requirement already satisfied: srsly<1.1.0,>=1.0.2 in /root/anaconda3/envs/covid/lib/python3.7/site-packages (from spacy>=2.2.1->en-ner-craft-md==0.2.4) (1.0.2)\n",
+      "Requirement already satisfied: preshed<3.1.0,>=3.0.2 in /root/anaconda3/envs/covid/lib/python3.7/site-packages (from spacy>=2.2.1->en-ner-craft-md==0.2.4) (3.0.2)\n",
+      "Requirement already satisfied: plac<1.2.0,>=0.9.6 in /root/anaconda3/envs/covid/lib/python3.7/site-packages (from spacy>=2.2.1->en-ner-craft-md==0.2.4) (1.1.3)\n",
+      "Requirement already satisfied: murmurhash<1.1.0,>=0.28.0 in /root/anaconda3/envs/covid/lib/python3.7/site-packages (from spacy>=2.2.1->en-ner-craft-md==0.2.4) (1.0.2)\n",
+      "Requirement already satisfied: tqdm<5.0.0,>=4.38.0 in /root/anaconda3/envs/covid/lib/python3.7/site-packages (from spacy>=2.2.1->en-ner-craft-md==0.2.4) (4.43.0)\n",
+      "Requirement already satisfied: thinc==7.4.0 in /root/anaconda3/envs/covid/lib/python3.7/site-packages (from spacy>=2.2.1->en-ner-craft-md==0.2.4) (7.4.0)\n",
+      "Requirement already satisfied: requests<3.0.0,>=2.13.0 in /root/anaconda3/envs/covid/lib/python3.7/site-packages (from spacy>=2.2.1->en-ner-craft-md==0.2.4) (2.23.0)\n",
+      "Requirement already satisfied: blis<0.5.0,>=0.4.0 in /root/anaconda3/envs/covid/lib/python3.7/site-packages (from spacy>=2.2.1->en-ner-craft-md==0.2.4) (0.4.1)\n",
+      "Requirement already satisfied: numpy>=1.15.0 in /root/anaconda3/envs/covid/lib/python3.7/site-packages (from spacy>=2.2.1->en-ner-craft-md==0.2.4) (1.18.2)\n",
+      "Requirement already satisfied: catalogue<1.1.0,>=0.0.7 in /root/anaconda3/envs/covid/lib/python3.7/site-packages (from spacy>=2.2.1->en-ner-craft-md==0.2.4) (1.0.0)\n",
+      "Requirement already satisfied: setuptools in /root/anaconda3/envs/covid/lib/python3.7/site-packages (from spacy>=2.2.1->en-ner-craft-md==0.2.4) (46.1.1.post20200323)\n",
+      "Requirement already satisfied: chardet<4,>=3.0.2 in /root/anaconda3/envs/covid/lib/python3.7/site-packages (from requests<3.0.0,>=2.13.0->spacy>=2.2.1->en-ner-craft-md==0.2.4) (3.0.4)\n",
+      "Requirement already satisfied: idna<3,>=2.5 in /root/anaconda3/envs/covid/lib/python3.7/site-packages (from requests<3.0.0,>=2.13.0->spacy>=2.2.1->en-ner-craft-md==0.2.4) (2.9)\n",
+      "Requirement already satisfied: certifi>=2017.4.17 in /root/anaconda3/envs/covid/lib/python3.7/site-packages (from requests<3.0.0,>=2.13.0->spacy>=2.2.1->en-ner-craft-md==0.2.4) (2019.11.28)\n",
+      "Requirement already satisfied: urllib3!=1.25.0,!=1.25.1,<1.26,>=1.21.1 in /root/anaconda3/envs/covid/lib/python3.7/site-packages (from requests<3.0.0,>=2.13.0->spacy>=2.2.1->en-ner-craft-md==0.2.4) (1.25.8)\n",
+      "Requirement already satisfied: importlib-metadata>=0.20; python_version < \"3.8\" in /root/anaconda3/envs/covid/lib/python3.7/site-packages (from catalogue<1.1.0,>=0.0.7->spacy>=2.2.1->en-ner-craft-md==0.2.4) (1.6.0)\n",
+      "Requirement already satisfied: zipp>=0.5 in /root/anaconda3/envs/covid/lib/python3.7/site-packages (from importlib-metadata>=0.20; python_version < \"3.8\"->catalogue<1.1.0,>=0.0.7->spacy>=2.2.1->en-ner-craft-md==0.2.4) (3.1.0)\n",
+      "Building wheels for collected packages: en-ner-craft-md\n",
+      "  Building wheel for en-ner-craft-md (setup.py) ... \u001b[?25ldone\n",
+      "\u001b[?25h  Created wheel for en-ner-craft-md: filename=en_ner_craft_md-0.2.4-py3-none-any.whl size=70540605 sha256=a4df528a3ccc56d69ce435e58836630a4a648d0ed65cd13eb98a2a182ed2bfb6\n",
+      "  Stored in directory: /root/.cache/pip/wheels/1a/ae/13/39630f5de846f590fd5d59c893c0632c11643a982715578037\n",
+      "Successfully built en-ner-craft-md\n",
+      "Installing collected packages: en-ner-craft-md\n",
+      "Successfully installed en-ner-craft-md-0.2.4\n",
+      "Collecting https://s3-us-west-2.amazonaws.com/ai2-s2-scispacy/releases/v0.2.4/en_ner_jnlpba_md-0.2.4.tar.gz\n",
+      "  Downloading https://s3-us-west-2.amazonaws.com/ai2-s2-scispacy/releases/v0.2.4/en_ner_jnlpba_md-0.2.4.tar.gz (70.1 MB)\n",
+      "\u001b[K     |████████████████████████████████| 70.1 MB 46.3 MB/s eta 0:00:01    |█████████████                   | 28.5 MB 4.8 MB/s eta 0:00:09    |█████████████████████████████▍  | 64.3 MB 46.3 MB/s eta 0:00:01     |██████████████████████████████▌ | 66.8 MB 46.3 MB/s eta 0:00:01\n",
+      "\u001b[?25hRequirement already satisfied: spacy>=2.2.1 in /root/anaconda3/envs/covid/lib/python3.7/site-packages (from en-ner-jnlpba-md==0.2.4) (2.2.4)\n",
+      "Requirement already satisfied: preshed<3.1.0,>=3.0.2 in /root/anaconda3/envs/covid/lib/python3.7/site-packages (from spacy>=2.2.1->en-ner-jnlpba-md==0.2.4) (3.0.2)\n",
+      "Requirement already satisfied: wasabi<1.1.0,>=0.4.0 in /root/anaconda3/envs/covid/lib/python3.7/site-packages (from spacy>=2.2.1->en-ner-jnlpba-md==0.2.4) (0.6.0)\n",
+      "Requirement already satisfied: srsly<1.1.0,>=1.0.2 in /root/anaconda3/envs/covid/lib/python3.7/site-packages (from spacy>=2.2.1->en-ner-jnlpba-md==0.2.4) (1.0.2)\n",
+      "Requirement already satisfied: tqdm<5.0.0,>=4.38.0 in /root/anaconda3/envs/covid/lib/python3.7/site-packages (from spacy>=2.2.1->en-ner-jnlpba-md==0.2.4) (4.43.0)\n",
+      "Requirement already satisfied: thinc==7.4.0 in /root/anaconda3/envs/covid/lib/python3.7/site-packages (from spacy>=2.2.1->en-ner-jnlpba-md==0.2.4) (7.4.0)\n",
+      "Requirement already satisfied: requests<3.0.0,>=2.13.0 in /root/anaconda3/envs/covid/lib/python3.7/site-packages (from spacy>=2.2.1->en-ner-jnlpba-md==0.2.4) (2.23.0)\n",
+      "Requirement already satisfied: numpy>=1.15.0 in /root/anaconda3/envs/covid/lib/python3.7/site-packages (from spacy>=2.2.1->en-ner-jnlpba-md==0.2.4) (1.18.2)\n",
+      "Requirement already satisfied: catalogue<1.1.0,>=0.0.7 in /root/anaconda3/envs/covid/lib/python3.7/site-packages (from spacy>=2.2.1->en-ner-jnlpba-md==0.2.4) (1.0.0)\n",
+      "Requirement already satisfied: setuptools in /root/anaconda3/envs/covid/lib/python3.7/site-packages (from spacy>=2.2.1->en-ner-jnlpba-md==0.2.4) (46.1.1.post20200323)\n",
+      "Requirement already satisfied: blis<0.5.0,>=0.4.0 in /root/anaconda3/envs/covid/lib/python3.7/site-packages (from spacy>=2.2.1->en-ner-jnlpba-md==0.2.4) (0.4.1)\n",
+      "Requirement already satisfied: murmurhash<1.1.0,>=0.28.0 in /root/anaconda3/envs/covid/lib/python3.7/site-packages (from spacy>=2.2.1->en-ner-jnlpba-md==0.2.4) (1.0.2)\n",
+      "Requirement already satisfied: plac<1.2.0,>=0.9.6 in /root/anaconda3/envs/covid/lib/python3.7/site-packages (from spacy>=2.2.1->en-ner-jnlpba-md==0.2.4) (1.1.3)\n",
+      "Requirement already satisfied: cymem<2.1.0,>=2.0.2 in /root/anaconda3/envs/covid/lib/python3.7/site-packages (from spacy>=2.2.1->en-ner-jnlpba-md==0.2.4) (2.0.3)\n",
+      "Requirement already satisfied: urllib3!=1.25.0,!=1.25.1,<1.26,>=1.21.1 in /root/anaconda3/envs/covid/lib/python3.7/site-packages (from requests<3.0.0,>=2.13.0->spacy>=2.2.1->en-ner-jnlpba-md==0.2.4) (1.25.8)\n",
+      "Requirement already satisfied: chardet<4,>=3.0.2 in /root/anaconda3/envs/covid/lib/python3.7/site-packages (from requests<3.0.0,>=2.13.0->spacy>=2.2.1->en-ner-jnlpba-md==0.2.4) (3.0.4)\n",
+      "Requirement already satisfied: idna<3,>=2.5 in /root/anaconda3/envs/covid/lib/python3.7/site-packages (from requests<3.0.0,>=2.13.0->spacy>=2.2.1->en-ner-jnlpba-md==0.2.4) (2.9)\n",
+      "Requirement already satisfied: certifi>=2017.4.17 in /root/anaconda3/envs/covid/lib/python3.7/site-packages (from requests<3.0.0,>=2.13.0->spacy>=2.2.1->en-ner-jnlpba-md==0.2.4) (2019.11.28)\n",
+      "Requirement already satisfied: importlib-metadata>=0.20; python_version < \"3.8\" in /root/anaconda3/envs/covid/lib/python3.7/site-packages (from catalogue<1.1.0,>=0.0.7->spacy>=2.2.1->en-ner-jnlpba-md==0.2.4) (1.6.0)\n",
+      "Requirement already satisfied: zipp>=0.5 in /root/anaconda3/envs/covid/lib/python3.7/site-packages (from importlib-metadata>=0.20; python_version < \"3.8\"->catalogue<1.1.0,>=0.0.7->spacy>=2.2.1->en-ner-jnlpba-md==0.2.4) (3.1.0)\n",
+      "Building wheels for collected packages: en-ner-jnlpba-md\n",
+      "  Building wheel for en-ner-jnlpba-md (setup.py) ... \u001b[?25ldone\n",
+      "\u001b[?25h  Created wheel for en-ner-jnlpba-md: filename=en_ner_jnlpba_md-0.2.4-py3-none-any.whl size=70531494 sha256=03b0dd1890b2def522c89a052dc9e6df7307b4a20bedda5af4a6cb9245b00975\n",
+      "  Stored in directory: /root/.cache/pip/wheels/f3/10/7f/791b971fb4dca08e20aea2b7c43133aa55456413830d70b7f4\n",
+      "Successfully built en-ner-jnlpba-md\n",
+      "Installing collected packages: en-ner-jnlpba-md\n",
+      "Successfully installed en-ner-jnlpba-md-0.2.4\n",
+      "Collecting https://s3-us-west-2.amazonaws.com/ai2-s2-scispacy/releases/v0.2.4/en_ner_bc5cdr_md-0.2.4.tar.gz\n",
+      "  Downloading https://s3-us-west-2.amazonaws.com/ai2-s2-scispacy/releases/v0.2.4/en_ner_bc5cdr_md-0.2.4.tar.gz (70.1 MB)\n",
+      "\u001b[K     |████████████████████████████████| 70.1 MB 47.2 MB/s eta 0:00:01B/s eta 0:00:11     |████████████████▎               | 35.7 MB 4.4 MB/s eta 0:00:08     |████████████████████████████    | 61.5 MB 47.2 MB/s eta 0:00:01     |██████████████████████████████▌ | 66.8 MB 47.2 MB/s eta 0:00:01\n",
+      "\u001b[?25hRequirement already satisfied: spacy>=2.2.1 in /root/anaconda3/envs/covid/lib/python3.7/site-packages (from en-ner-bc5cdr-md==0.2.4) (2.2.4)\n",
+      "Requirement already satisfied: tqdm<5.0.0,>=4.38.0 in /root/anaconda3/envs/covid/lib/python3.7/site-packages (from spacy>=2.2.1->en-ner-bc5cdr-md==0.2.4) (4.43.0)\n",
+      "Requirement already satisfied: preshed<3.1.0,>=3.0.2 in /root/anaconda3/envs/covid/lib/python3.7/site-packages (from spacy>=2.2.1->en-ner-bc5cdr-md==0.2.4) (3.0.2)\n",
+      "Requirement already satisfied: cymem<2.1.0,>=2.0.2 in /root/anaconda3/envs/covid/lib/python3.7/site-packages (from spacy>=2.2.1->en-ner-bc5cdr-md==0.2.4) (2.0.3)\n",
+      "Requirement already satisfied: blis<0.5.0,>=0.4.0 in /root/anaconda3/envs/covid/lib/python3.7/site-packages (from spacy>=2.2.1->en-ner-bc5cdr-md==0.2.4) (0.4.1)\n",
+      "Requirement already satisfied: catalogue<1.1.0,>=0.0.7 in /root/anaconda3/envs/covid/lib/python3.7/site-packages (from spacy>=2.2.1->en-ner-bc5cdr-md==0.2.4) (1.0.0)\n",
+      "Requirement already satisfied: numpy>=1.15.0 in /root/anaconda3/envs/covid/lib/python3.7/site-packages (from spacy>=2.2.1->en-ner-bc5cdr-md==0.2.4) (1.18.2)\n",
+      "Requirement already satisfied: srsly<1.1.0,>=1.0.2 in /root/anaconda3/envs/covid/lib/python3.7/site-packages (from spacy>=2.2.1->en-ner-bc5cdr-md==0.2.4) (1.0.2)\n",
+      "Requirement already satisfied: setuptools in /root/anaconda3/envs/covid/lib/python3.7/site-packages (from spacy>=2.2.1->en-ner-bc5cdr-md==0.2.4) (46.1.1.post20200323)\n",
+      "Requirement already satisfied: plac<1.2.0,>=0.9.6 in /root/anaconda3/envs/covid/lib/python3.7/site-packages (from spacy>=2.2.1->en-ner-bc5cdr-md==0.2.4) (1.1.3)\n",
+      "Requirement already satisfied: wasabi<1.1.0,>=0.4.0 in /root/anaconda3/envs/covid/lib/python3.7/site-packages (from spacy>=2.2.1->en-ner-bc5cdr-md==0.2.4) (0.6.0)\n",
+      "Requirement already satisfied: requests<3.0.0,>=2.13.0 in /root/anaconda3/envs/covid/lib/python3.7/site-packages (from spacy>=2.2.1->en-ner-bc5cdr-md==0.2.4) (2.23.0)\n",
+      "Requirement already satisfied: murmurhash<1.1.0,>=0.28.0 in /root/anaconda3/envs/covid/lib/python3.7/site-packages (from spacy>=2.2.1->en-ner-bc5cdr-md==0.2.4) (1.0.2)\n",
+      "Requirement already satisfied: thinc==7.4.0 in /root/anaconda3/envs/covid/lib/python3.7/site-packages (from spacy>=2.2.1->en-ner-bc5cdr-md==0.2.4) (7.4.0)\n",
+      "Requirement already satisfied: importlib-metadata>=0.20; python_version < \"3.8\" in /root/anaconda3/envs/covid/lib/python3.7/site-packages (from catalogue<1.1.0,>=0.0.7->spacy>=2.2.1->en-ner-bc5cdr-md==0.2.4) (1.6.0)\n",
+      "Requirement already satisfied: idna<3,>=2.5 in /root/anaconda3/envs/covid/lib/python3.7/site-packages (from requests<3.0.0,>=2.13.0->spacy>=2.2.1->en-ner-bc5cdr-md==0.2.4) (2.9)\n",
+      "Requirement already satisfied: chardet<4,>=3.0.2 in /root/anaconda3/envs/covid/lib/python3.7/site-packages (from requests<3.0.0,>=2.13.0->spacy>=2.2.1->en-ner-bc5cdr-md==0.2.4) (3.0.4)\n",
+      "Requirement already satisfied: urllib3!=1.25.0,!=1.25.1,<1.26,>=1.21.1 in /root/anaconda3/envs/covid/lib/python3.7/site-packages (from requests<3.0.0,>=2.13.0->spacy>=2.2.1->en-ner-bc5cdr-md==0.2.4) (1.25.8)\n",
+      "Requirement already satisfied: certifi>=2017.4.17 in /root/anaconda3/envs/covid/lib/python3.7/site-packages (from requests<3.0.0,>=2.13.0->spacy>=2.2.1->en-ner-bc5cdr-md==0.2.4) (2019.11.28)\n",
+      "Requirement already satisfied: zipp>=0.5 in /root/anaconda3/envs/covid/lib/python3.7/site-packages (from importlib-metadata>=0.20; python_version < \"3.8\"->catalogue<1.1.0,>=0.0.7->spacy>=2.2.1->en-ner-bc5cdr-md==0.2.4) (3.1.0)\n",
+      "Building wheels for collected packages: en-ner-bc5cdr-md\n",
+      "  Building wheel for en-ner-bc5cdr-md (setup.py) ... \u001b[?25ldone\n",
+      "\u001b[?25h  Created wheel for en-ner-bc5cdr-md: filename=en_ner_bc5cdr_md-0.2.4-py3-none-any.whl size=70531464 sha256=3dc66f57c19502dbf5cff3f9f4c14812efa4172f89b2f37e487f2c71c4fbf3a8\n",
+      "  Stored in directory: /root/.cache/pip/wheels/7c/f4/2d/75a2d2f28a86df956116d40993f5f81df5f5522665c89230eb\n",
+      "Successfully built en-ner-bc5cdr-md\n",
+      "Installing collected packages: en-ner-bc5cdr-md\n",
+      "Successfully installed en-ner-bc5cdr-md-0.2.4\n",
+      "Collecting https://s3-us-west-2.amazonaws.com/ai2-s2-scispacy/releases/v0.2.4/en_ner_bionlp13cg_md-0.2.4.tar.gz\n",
+      "  Downloading https://s3-us-west-2.amazonaws.com/ai2-s2-scispacy/releases/v0.2.4/en_ner_bionlp13cg_md-0.2.4.tar.gz (70.1 MB)\n",
+      "\u001b[K     |████████████████████████████████| 70.1 MB 43.1 MB/s eta 0:00:01     |██████████████████████████████▉ | 67.6 MB 43.1 MB/s eta 0:00:01\n",
+      "\u001b[?25hRequirement already satisfied: spacy>=2.2.1 in /root/anaconda3/envs/covid/lib/python3.7/site-packages (from en-ner-bionlp13cg-md==0.2.4) (2.2.4)\n",
+      "Requirement already satisfied: thinc==7.4.0 in /root/anaconda3/envs/covid/lib/python3.7/site-packages (from spacy>=2.2.1->en-ner-bionlp13cg-md==0.2.4) (7.4.0)\n",
+      "Requirement already satisfied: requests<3.0.0,>=2.13.0 in /root/anaconda3/envs/covid/lib/python3.7/site-packages (from spacy>=2.2.1->en-ner-bionlp13cg-md==0.2.4) (2.23.0)\n",
+      "Requirement already satisfied: blis<0.5.0,>=0.4.0 in /root/anaconda3/envs/covid/lib/python3.7/site-packages (from spacy>=2.2.1->en-ner-bionlp13cg-md==0.2.4) (0.4.1)\n",
+      "Requirement already satisfied: numpy>=1.15.0 in /root/anaconda3/envs/covid/lib/python3.7/site-packages (from spacy>=2.2.1->en-ner-bionlp13cg-md==0.2.4) (1.18.2)\n",
+      "Requirement already satisfied: cymem<2.1.0,>=2.0.2 in /root/anaconda3/envs/covid/lib/python3.7/site-packages (from spacy>=2.2.1->en-ner-bionlp13cg-md==0.2.4) (2.0.3)\n",
+      "Requirement already satisfied: murmurhash<1.1.0,>=0.28.0 in /root/anaconda3/envs/covid/lib/python3.7/site-packages (from spacy>=2.2.1->en-ner-bionlp13cg-md==0.2.4) (1.0.2)\n",
+      "Requirement already satisfied: plac<1.2.0,>=0.9.6 in /root/anaconda3/envs/covid/lib/python3.7/site-packages (from spacy>=2.2.1->en-ner-bionlp13cg-md==0.2.4) (1.1.3)\n",
+      "Requirement already satisfied: preshed<3.1.0,>=3.0.2 in /root/anaconda3/envs/covid/lib/python3.7/site-packages (from spacy>=2.2.1->en-ner-bionlp13cg-md==0.2.4) (3.0.2)\n",
+      "Requirement already satisfied: srsly<1.1.0,>=1.0.2 in /root/anaconda3/envs/covid/lib/python3.7/site-packages (from spacy>=2.2.1->en-ner-bionlp13cg-md==0.2.4) (1.0.2)\n",
+      "Requirement already satisfied: setuptools in /root/anaconda3/envs/covid/lib/python3.7/site-packages (from spacy>=2.2.1->en-ner-bionlp13cg-md==0.2.4) (46.1.1.post20200323)\n",
+      "Requirement already satisfied: tqdm<5.0.0,>=4.38.0 in /root/anaconda3/envs/covid/lib/python3.7/site-packages (from spacy>=2.2.1->en-ner-bionlp13cg-md==0.2.4) (4.43.0)\n",
+      "Requirement already satisfied: wasabi<1.1.0,>=0.4.0 in /root/anaconda3/envs/covid/lib/python3.7/site-packages (from spacy>=2.2.1->en-ner-bionlp13cg-md==0.2.4) (0.6.0)\n",
+      "Requirement already satisfied: catalogue<1.1.0,>=0.0.7 in /root/anaconda3/envs/covid/lib/python3.7/site-packages (from spacy>=2.2.1->en-ner-bionlp13cg-md==0.2.4) (1.0.0)\n",
+      "Requirement already satisfied: chardet<4,>=3.0.2 in /root/anaconda3/envs/covid/lib/python3.7/site-packages (from requests<3.0.0,>=2.13.0->spacy>=2.2.1->en-ner-bionlp13cg-md==0.2.4) (3.0.4)\n",
+      "Requirement already satisfied: certifi>=2017.4.17 in /root/anaconda3/envs/covid/lib/python3.7/site-packages (from requests<3.0.0,>=2.13.0->spacy>=2.2.1->en-ner-bionlp13cg-md==0.2.4) (2019.11.28)\n",
+      "Requirement already satisfied: idna<3,>=2.5 in /root/anaconda3/envs/covid/lib/python3.7/site-packages (from requests<3.0.0,>=2.13.0->spacy>=2.2.1->en-ner-bionlp13cg-md==0.2.4) (2.9)\n",
+      "Requirement already satisfied: urllib3!=1.25.0,!=1.25.1,<1.26,>=1.21.1 in /root/anaconda3/envs/covid/lib/python3.7/site-packages (from requests<3.0.0,>=2.13.0->spacy>=2.2.1->en-ner-bionlp13cg-md==0.2.4) (1.25.8)\n",
+      "Requirement already satisfied: importlib-metadata>=0.20; python_version < \"3.8\" in /root/anaconda3/envs/covid/lib/python3.7/site-packages (from catalogue<1.1.0,>=0.0.7->spacy>=2.2.1->en-ner-bionlp13cg-md==0.2.4) (1.6.0)\n",
+      "Requirement already satisfied: zipp>=0.5 in /root/anaconda3/envs/covid/lib/python3.7/site-packages (from importlib-metadata>=0.20; python_version < \"3.8\"->catalogue<1.1.0,>=0.0.7->spacy>=2.2.1->en-ner-bionlp13cg-md==0.2.4) (3.1.0)\n",
+      "Building wheels for collected packages: en-ner-bionlp13cg-md\n",
+      "  Building wheel for en-ner-bionlp13cg-md (setup.py) ... \u001b[?25ldone\n",
+      "\u001b[?25h  Created wheel for en-ner-bionlp13cg-md: filename=en_ner_bionlp13cg_md-0.2.4-py3-none-any.whl size=70542690 sha256=af92df3b5c48f9e4c8d5259669355e722a7002d4fd3bc23da310adbf8bd76458\n",
+      "  Stored in directory: /root/.cache/pip/wheels/50/b2/7d/53cff131cb37c8b0197b02f45eb827ff4bb00b119c3a591b4d\n",
+      "Successfully built en-ner-bionlp13cg-md\n",
+      "Installing collected packages: en-ner-bionlp13cg-md\n",
+      "Successfully installed en-ner-bionlp13cg-md-0.2.4\n"
+     ]
+    }
+   ],
+   "source": [
+    "!pip install https://s3-us-west-2.amazonaws.com/ai2-s2-scispacy/releases/v0.2.4/en_ner_craft_md-0.2.4.tar.gz\n",
+    "!pip install https://s3-us-west-2.amazonaws.com/ai2-s2-scispacy/releases/v0.2.4/en_ner_jnlpba_md-0.2.4.tar.gz\n",
+    "!pip install https://s3-us-west-2.amazonaws.com/ai2-s2-scispacy/releases/v0.2.4/en_ner_bc5cdr_md-0.2.4.tar.gz\n",
+    "!pip install https://s3-us-west-2.amazonaws.com/ai2-s2-scispacy/releases/v0.2.4/en_ner_bionlp13cg_md-0.2.4.tar.gz"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import spacy \n",
+    "import scispacy\n",
+    "import pandas as pd \n",
+    "import os\n",
+    "import numpy as np\n",
+    "import json\n",
+    "from tqdm import tqdm\n",
+    "import ipywidgets as widgets\n",
+    "import time"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Here, we can list our models, and load each one as a separate spaCy processing pipeline. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "models = [\"en_ner_craft_md\", \"en_ner_jnlpba_md\",\"en_ner_bc5cdr_md\",\"en_ner_bionlp13cg_md\"]\n",
+    "nlps = [spacy.load(model) for model in models]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This is system specific. I broke the original dataset into 1000 parts, to make it easier to manage memory consumption on a remote server. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "files_to_process = [f for f in os.listdir(\"df_parts/\") if f.endswith(\"processed.csv\")]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Generating the output\n",
+    "\n",
+    "This function will read each file in, and then process sentence-by-sentence with each NER model, and output extracted entities to the appropriate columns. Afterwards, the file is saved. Later, we can concatenate these files into a single dataframe. Note here that we need to define each of those columns as an \"object\" type, or else df.at[i,j] won't be able to assign lists to the cells."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  0%|          | 0/269 [00:00<?, ?it/s]\u001b[A\n",
+      "  0%|          | 1/269 [02:15<10:05:12, 135.49s/it]\u001b[A\n",
+      "  1%|          | 2/269 [04:48<10:25:52, 140.65s/it]\u001b[A\n",
+      "  1%|          | 3/269 [07:22<10:41:31, 144.70s/it]\u001b[A\n",
+      "  1%|▏         | 4/269 [10:05<11:03:54, 150.32s/it]\u001b[A\n",
+      "  2%|▏         | 5/269 [12:36<11:01:43, 150.39s/it]\u001b[A\n",
+      "  2%|▏         | 6/269 [14:49<10:36:56, 145.31s/it]\u001b[A\n",
+      "  3%|▎         | 7/269 [17:16<10:36:57, 145.87s/it]\u001b[A\n",
+      "  3%|▎         | 8/269 [19:41<10:33:23, 145.61s/it]\u001b[A\n",
+      "  3%|▎         | 9/269 [22:13<10:38:55, 147.44s/it]\u001b[A\n",
+      "  4%|▎         | 10/269 [24:53<10:52:27, 151.15s/it]\u001b[A\n",
+      "  4%|▍         | 11/269 [27:29<10:55:52, 152.53s/it]\u001b[A\n",
+      "  4%|▍         | 12/269 [29:45<10:32:53, 147.76s/it]\u001b[A\n",
+      "  5%|▍         | 13/269 [32:31<10:53:26, 153.15s/it]\u001b[A"
+     ]
+    }
+   ],
+   "source": [
+    "for f in tqdm(files_to_process):\n",
+    "    scispacy_ent_types = ['GGP', 'SO', 'TAXON', 'CHEBI', 'GO', 'CL', 'DNA', 'CELL_TYPE', 'CELL_LINE', 'RNA', 'PROTEIN', \n",
+    "                          'DISEASE', 'CHEMICAL', 'CANCER', 'ORGAN', 'TISSUE', 'ORGANISM', 'CELL', 'AMINO_ACID',\n",
+    "                          'GENE_OR_GENE_PRODUCT', 'SIMPLE_CHEMICAL', 'ANATOMICAL_SYSTEM', 'IMMATERIAL_ANATOMICAL_ENTITY',\n",
+    "                          'MULTI-TISSUE_STRUCTURE', 'DEVELOPING_ANATOMICAL_STRUCTURE', 'ORGANISM_SUBDIVISION',\n",
+    "                          'CELLULAR_COMPONENT', 'PATHOLOGICAL_FORMATION']\n",
+    "    df = pd.read_csv(\"df_parts/\"+f)\n",
+    "    df = pd.concat([df,pd.DataFrame(columns=scispacy_ent_types)])\n",
+    "    for col in scispacy_ent_types:\n",
+    "        df[col] = df[col].astype(\"object\")\n",
+    "        \n",
+    "    for i in df.index:\n",
+    "        if df.iloc[i][\"language\"] == \"en\":\n",
+    "            for nlp in nlps:\n",
+    "                doc = nlp(str(df.iloc[i][\"sentence\"]))\n",
+    "                keys = list(set([ent.label_ for ent in doc.ents]))\n",
+    "                for key in keys:\n",
+    "                    \n",
+    "                    # Some entity types are present in the model, but not in the documentation! \n",
+    "                    # In that case, we'll just automatically add it to the df. \n",
+    "                    if key not in scispacy_ent_types:\n",
+    "                        df = pd.concat([df,pd.DataFrame(columns=[key])])\n",
+    "                        df[key] = df[key].astype(\"object\")\n",
+    "                        \n",
+    "                    values = [ent.text for ent in doc.ents if ent.label_ == key]\n",
+    "                    df.at[i,key] = values\n",
+    "        else:\n",
+    "            pass\n",
+    "    filename = \"df_parts/\" + str(f.split(\"_\")[0]) + \"_complete.csv\"\n",
+    "    df.to_csv(filename,index=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Putting it all together\n",
+    "\n",
+    "Now let's concatenate everything together, save it to a master file, and use it for data analysis!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "files_to_join = [i for i in os.listdir(\"df_parts\") if i.endswith(\"complete.csv\")]\n",
+    "df_list = []\n",
+    "for i in tqdm(files_to_join):\n",
+    "    df_list.append(pd.read_csv(i))\n",
+    "df = pd.concat(df_list,ignore_index=True)\n",
+    "df.to_csv(\"fulltext_processed_03302020.csv\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION

Fixes #5 
 #Upload notebook with functionality for fine-grained NER over all articles, titles, abstracts, figures, and tables, with the following types of entities:
['GGP', 'SO', 'TAXON', 'CHEBI', 'GO', 'CL', 'DNA', 'CELL_TYPE', 'CELL_LINE', 'RNA', 'PROTEIN',
                      'DISEASE', 'CHEMICAL', 'CANCER', 'ORGAN', 'TISSUE', 'ORGANISM', 'CELL', 'AMINO_ACID',
                      'GENE_OR_GENE_PRODUCT', 'SIMPLE_CHEMICAL', 'ANATOMICAL_SYSTEM', 'IMMATERIAL_ANATOMICAL_ENTITY',
                      'MULTI-TISSUE_STRUCTURE', 'DEVELOPING_ANATOMICAL_STRUCTURE', 'ORGANISM_SUBDIVISION',
                      'CELLULAR_COMPONENT', 'UMLS']